### PR TITLE
Fix silent RSN drop past Supabase's 1000-row default fetch cap

### DIFF
--- a/admin-bot/add_member_rsns_normalized_column.sql
+++ b/admin-bot/add_member_rsns_normalized_column.sql
@@ -1,0 +1,15 @@
+-- Adds a generated, indexed column mirroring Python's normalize_string()
+-- (lower + strip spaces/underscores/dashes/dots) so RSN lookups can be
+-- pushed server-side instead of fetching the whole member_rsns table and
+-- normalizing in Python.
+--
+-- Not unique: normalize_string() collisions already exist in the table
+-- (e.g. "Bonnie Moo" and "bonnie moo" as separate rows), so lookups on
+-- this column can still return >1 row for those RSNs.
+ALTER TABLE public.member_rsns
+  ADD COLUMN normalized_rsn text
+  GENERATED ALWAYS AS (
+    lower(regexp_replace(rsn, '[ _\-.]', '', 'g'))
+  ) STORED;
+
+CREATE INDEX idx_member_rsns_normalized_rsn ON public.member_rsns (normalized_rsn);

--- a/admin-bot/bot.py
+++ b/admin-bot/bot.py
@@ -108,8 +108,8 @@ def resolve_rsn_to_member(rsn: str) -> dict | None:
         if not normalized_input:
             return None
             
-        res = supabase.table('member_rsns').select('member_id, rsn').execute()
-        for row in res.data:
+        rows = clan_sync_logic.fetch_all_rows(supabase.table('member_rsns').select('member_id, rsn'))
+        for row in rows:
             if normalize_string(row['rsn']) == normalized_input:
                 return {
                     'member_id': row['member_id'],
@@ -1723,10 +1723,10 @@ async def bulk_add_points(interaction: discord.Interaction, points: int, reason:
         # 2. Build RSN Map (Optimization: Fetch all members once)
         # We need to resolve RSN -> Member ID
         log.info("Building RSN map for bulk add points...")
-        all_rsns_res = supabase.table('member_rsns').select('rsn, member_id').execute()
-        
+        all_rsns_data = clan_sync_logic.fetch_all_rows(supabase.table('member_rsns').select('rsn, member_id'))
+
         rsn_map = {}
-        for item in all_rsns_res.data:
+        for item in all_rsns_data:
             rsn_map[normalize_string(item['rsn'])] = {
                 "member_id": item['member_id'],
                 "original_rsn": item['rsn']
@@ -1911,8 +1911,8 @@ async def process_competition_points(
     try:
         # 2. Resolve RSNs to Member IDs
         # Fetch all member RSNs to minimize queries (or we could `in_` query if list is small, but map is safer for normalization)
-        all_rsns_res = supabase.table('member_rsns').select('rsn, member_id').execute()
-        rsn_map = {normalize_string(item['rsn']): item for item in all_rsns_res.data}
+        all_rsns_data = clan_sync_logic.fetch_all_rows(supabase.table('member_rsns').select('rsn, member_id'))
+        rsn_map = {normalize_string(item['rsn']): item for item in all_rsns_data}
 
         transactions = []
         report_lines = []

--- a/admin-bot/bot.py
+++ b/admin-bot/bot.py
@@ -107,15 +107,18 @@ def resolve_rsn_to_member(rsn: str) -> dict | None:
         normalized_input = normalize_string(rsn)
         if not normalized_input:
             return None
-            
-        rows = clan_sync_logic.fetch_all_rows(supabase.table('member_rsns').select('member_id, rsn'))
-        for row in rows:
-            if normalize_string(row['rsn']) == normalized_input:
-                return {
-                    'member_id': row['member_id'],
-                    'rsn': row['rsn']
-                }
-        return None
+
+        res = supabase.table('member_rsns') \
+            .select('member_id, rsn') \
+            .eq('normalized_rsn', normalized_input) \
+            .order('is_primary', desc=True) \
+            .execute()
+        if not res.data:
+            return None
+        return {
+            'member_id': res.data[0]['member_id'],
+            'rsn': res.data[0]['rsn']
+        }
     except Exception as e:
         log.error(f"Error resolving RSN '{rsn}': {e}")
         return None
@@ -1094,8 +1097,8 @@ async def rankup(interaction: discord.Interaction, rsn: str, rank_name: str, pub
 
         member_res = supabase.table('member_rsns') \
             .select('member_id, rsn, members(current_rank_id, discord_id, ranks(hierarchy_level))') \
-            .ilike('rsn', rsn) \
-            .limit(1) \
+            .eq('normalized_rsn', normalize_string(rsn)) \
+            .order('is_primary', desc=True) \
             .execute()
 
         if not member_res.data:
@@ -1229,18 +1232,26 @@ async def bulkrankup(interaction: discord.Interaction, rank_name: str, rsn_list:
         new_rank_id = new_rank['id']
         new_rank_name = new_rank['name']
 
+        rsns_to_process = [r.strip() for r in rsn_list.split(',') if r.strip()]
+
         log.info("Building RSN map for bulk rankup...")
+        normalized_inputs = list({normalize_string(r) for r in rsns_to_process})
         rsns_res = supabase.table('member_rsns') \
             .select('rsn, member_id, members(current_rank_id, discord_id, ranks(hierarchy_level))') \
+            .in_('normalized_rsn', normalized_inputs) \
+            .order('is_primary', desc=True) \
             .execute()
-        
+
         rsn_map = {}
         for item in rsns_res.data:
+            key = normalize_string(item['rsn'])
+            if key in rsn_map:
+                continue  # already have the is_primary row for this normalized RSN
             if item.get('members'):
                 old_h = 0
                 if item['members'].get('ranks'):
                     old_h = item['members']['ranks'].get('hierarchy_level', 0)
-                rsn_map[normalize_string(item['rsn'])] = {
+                rsn_map[key] = {
                     "member_id": item['member_id'],
                     "original_rsn": item['rsn'],
                     "old_rank_id": item['members']['current_rank_id'],
@@ -1249,8 +1260,6 @@ async def bulkrankup(interaction: discord.Interaction, rank_name: str, rsn_list:
                 }
         log.info("RSN map built.")
 
-        rsns_to_process = [r.strip() for r in rsn_list.split(',')]
-        
         member_ids_to_update = []
         history_payload = []
         successful_discord_members = []
@@ -1720,14 +1729,22 @@ async def bulk_add_points(interaction: discord.Interaction, points: int, reason:
             await interaction.followup.send("Error: No RSNs provided.", ephemeral=True)
             return
 
-        # 2. Build RSN Map (Optimization: Fetch all members once)
+        # 2. Build RSN Map (Optimization: only fetch rows matching the requested RSNs)
         # We need to resolve RSN -> Member ID
         log.info("Building RSN map for bulk add points...")
-        all_rsns_data = clan_sync_logic.fetch_all_rows(supabase.table('member_rsns').select('rsn, member_id'))
+        normalized_inputs = list({normalize_string(r) for r in rsns_to_process})
+        all_rsns_res = supabase.table('member_rsns') \
+            .select('rsn, member_id') \
+            .in_('normalized_rsn', normalized_inputs) \
+            .order('is_primary', desc=True) \
+            .execute()
 
         rsn_map = {}
-        for item in all_rsns_data:
-            rsn_map[normalize_string(item['rsn'])] = {
+        for item in all_rsns_res.data:
+            key = normalize_string(item['rsn'])
+            if key in rsn_map:
+                continue  # already have the is_primary row for this normalized RSN
+            rsn_map[key] = {
                 "member_id": item['member_id'],
                 "original_rsn": item['rsn']
             }
@@ -1909,10 +1926,18 @@ async def process_competition_points(
         return
 
     try:
-        # 2. Resolve RSNs to Member IDs
-        # Fetch all member RSNs to minimize queries (or we could `in_` query if list is small, but map is safer for normalization)
-        all_rsns_data = clan_sync_logic.fetch_all_rows(supabase.table('member_rsns').select('rsn, member_id'))
-        rsn_map = {normalize_string(item['rsn']): item for item in all_rsns_data}
+        # 2. Resolve RSNs to Member IDs (only fetch rows matching the requested RSNs)
+        normalized_inputs = list({normalize_string(t['rsn']) for t in targets})
+        all_rsns_res = supabase.table('member_rsns') \
+            .select('rsn, member_id') \
+            .in_('normalized_rsn', normalized_inputs) \
+            .order('is_primary', desc=True) \
+            .execute()
+        rsn_map = {}
+        for item in all_rsns_res.data:
+            key = normalize_string(item['rsn'])
+            if key not in rsn_map:
+                rsn_map[key] = item  # first-seen wins; is_primary rows sort first
 
         transactions = []
         report_lines = []
@@ -2145,12 +2170,14 @@ async def check_inactivity_exemptions(interaction: discord.Interaction, publish:
             await interaction.followup.send("✅ No active inactivity exemptions found.", ephemeral=is_ephemeral)
             return
 
-        # Fetch all primary RSNs to build a mapping from member_id -> RSN
+        # Fetch primary RSNs for the affected members to build a mapping from member_id -> RSN
+        exempt_member_ids = list({e['member_id'] for e in exemptions_data})
         rsn_res = supabase.table('member_rsns') \
             .select('member_id, rsn') \
             .eq('is_primary', True) \
+            .in_('member_id', exempt_member_ids) \
             .execute()
-        
+
         rsn_map = {item['member_id']: item['rsn'] for item in rsn_res.data or []}
         
         # Sort exemptions by expiration_date ascending (closest to expire first)
@@ -2222,18 +2249,14 @@ async def expire_exemption(interaction: discord.Interaction, rsn: str, publish: 
     
     try:
         # 1. Find the member by RSN
-        member_res = supabase.table('member_rsns') \
-            .select('member_id, rsn') \
-            .ilike('rsn', rsn) \
-            .limit(1) \
-            .execute()
-            
-        if not member_res.data:
+        resolved = resolve_rsn_to_member(rsn)
+
+        if not resolved:
             await interaction.followup.send(f"Error: RSN `{rsn}` not found in the database.", ephemeral=True)
             return
-            
-        member_id = member_res.data[0]['member_id']
-        member_rsn = member_res.data[0]['rsn']
+
+        member_id = resolved['member_id']
+        member_rsn = resolved['rsn']
         
         # 2. Check if they have an active exemption
         now_str = datetime.now().isoformat()

--- a/admin-bot/clan_sync_logic.py
+++ b/admin-bot/clan_sync_logic.py
@@ -114,12 +114,15 @@ def fetch_db_ranks_and_rsns(supabase: Client) -> (dict, dict, dict):
             ranks_map_by_id[rank['id']] = rank['name']
         
         
-        rsns_query = supabase.table('member_rsns').select('rsn, member_id, is_primary')
+        rsns_query = supabase.table('member_rsns').select('rsn, member_id, is_primary').order('is_primary', desc=True)
         rsns_data = fetch_all_rows(rsns_query)
-        
+
         db_rsn_map_normalized = {}
         for item in rsns_data:
-            db_rsn_map_normalized[normalize_string(item['rsn'])] = {
+            key = normalize_string(item['rsn'])
+            if key in db_rsn_map_normalized:
+                continue  # already have the is_primary row for this normalized RSN
+            db_rsn_map_normalized[key] = {
                 "member_id": item['member_id'],
                 "is_primary": item['is_primary'],
                 "original_rsn": item['rsn']

--- a/admin-bot/dbschema.sql
+++ b/admin-bot/dbschema.sql
@@ -61,9 +61,14 @@ CREATE TABLE public.member_rsns (
   rsn character varying NOT NULL UNIQUE,
   is_primary boolean NOT NULL DEFAULT true,
   date_changed timestamp with time zone NOT NULL DEFAULT now(),
+  normalized_rsn text GENERATED ALWAYS AS (lower(regexp_replace(rsn, '[ _\-.]', '', 'g'))) STORED,
   CONSTRAINT member_rsns_pkey PRIMARY KEY (id),
   CONSTRAINT member_rsns_member_id_fkey FOREIGN KEY (member_id) REFERENCES public.members(id)
 );
+-- normalized_rsn is not unique: pre-existing rows collide under normalize_string()
+-- (e.g. "Bonnie Moo" / "bonnie moo" both exist as separate rows), so lookups on
+-- this column can still return >1 row for those RSNs. Indexed via
+-- idx_member_rsns_normalized_rsn (see add_member_rsns_normalized_column.sql).
 CREATE TABLE public.members (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   discord_id bigint UNIQUE,

--- a/admin-bot/inactivity_logic.py
+++ b/admin-bot/inactivity_logic.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 from supabase import create_client, Client
 import sys # <-- Import sys
 import logging
+import clan_sync_logic
 
 # Initialize the logger for your bot's custom messages
 log = logging.getLogger('ClanBot') 
@@ -76,8 +77,8 @@ def get_active_members_with_snapshots(supabase: Client) -> list:
             })
         
         # Fetch RSNs
-        rsn_response = supabase.table('member_rsns').select('member_id, rsn').eq('is_primary', True).execute()
-        rsn_map = {item['member_id']: item['rsn'] for item in rsn_response.data}
+        rsn_data = clan_sync_logic.fetch_all_rows(supabase.table('member_rsns').select('member_id, rsn').eq('is_primary', True))
+        rsn_map = {item['member_id']: item['rsn'] for item in rsn_data}
         
         # Fetch rank names
         rank_response = supabase.table('ranks').select('id, name').execute()

--- a/admin-bot/overachievers_logic.py
+++ b/admin-bot/overachievers_logic.py
@@ -3,6 +3,7 @@ import requests
 import discord
 from supabase import Client
 import logging
+import clan_sync_logic
 
 log = logging.getLogger('ClanBot')
 
@@ -70,8 +71,8 @@ def run_overachievers_check(supabase: Client, dry_run: bool = True) -> tuple:
         return None, None, None, "Missing WOM API credentials."
 
     log.info("Fetching members from DB...")
-    rsn_res = supabase.table('member_rsns').select('rsn, member_id').execute()
-    db_rsn_map = {normalize_string(row['rsn']): row['member_id'] for row in rsn_res.data}
+    rsn_data = clan_sync_logic.fetch_all_rows(supabase.table('member_rsns').select('rsn, member_id'))
+    db_rsn_map = {normalize_string(row['rsn']): row['member_id'] for row in rsn_data}
 
     log.info("Fetching previous overachievers...")
     recent_res = supabase.table('overachievers').select('metric, member_id, value, global_rank, date').order('date', desc=True).execute()
@@ -213,8 +214,8 @@ def get_overachiever_lookup(supabase: Client, query: str) -> tuple[discord.Embed
         
     else:
         # It's an RSN query
-        rsn_res = supabase.table('member_rsns').select('member_id, rsn, is_primary').execute()
-        matched_rows = [row for row in rsn_res.data if normalize_string(row['rsn']) == normalized_query]
+        rsn_data = clan_sync_logic.fetch_all_rows(supabase.table('member_rsns').select('member_id, rsn, is_primary'))
+        matched_rows = [row for row in rsn_data if normalize_string(row['rsn']) == normalized_query]
         
         if not matched_rows:
             return None, f"Could not find any member with RSN: '{query}' or any metric called '{query}'."

--- a/admin-bot/overachievers_logic.py
+++ b/admin-bot/overachievers_logic.py
@@ -71,8 +71,14 @@ def run_overachievers_check(supabase: Client, dry_run: bool = True) -> tuple:
         return None, None, None, "Missing WOM API credentials."
 
     log.info("Fetching members from DB...")
-    rsn_data = clan_sync_logic.fetch_all_rows(supabase.table('member_rsns').select('rsn, member_id'))
-    db_rsn_map = {normalize_string(row['rsn']): row['member_id'] for row in rsn_data}
+    rsn_data = clan_sync_logic.fetch_all_rows(
+        supabase.table('member_rsns').select('rsn, member_id, is_primary').order('is_primary', desc=True)
+    )
+    db_rsn_map = {}
+    for row in rsn_data:
+        key = normalize_string(row['rsn'])
+        if key not in db_rsn_map:
+            db_rsn_map[key] = row['member_id']  # first-seen wins; is_primary rows sort first
 
     log.info("Fetching previous overachievers...")
     recent_res = supabase.table('overachievers').select('metric, member_id, value, global_rank, date').order('date', desc=True).execute()
@@ -214,13 +220,16 @@ def get_overachiever_lookup(supabase: Client, query: str) -> tuple[discord.Embed
         
     else:
         # It's an RSN query
-        rsn_data = clan_sync_logic.fetch_all_rows(supabase.table('member_rsns').select('member_id, rsn, is_primary'))
-        matched_rows = [row for row in rsn_data if normalize_string(row['rsn']) == normalized_query]
-        
-        if not matched_rows:
+        rsn_res = supabase.table('member_rsns') \
+            .select('member_id, rsn, is_primary') \
+            .eq('normalized_rsn', normalized_query) \
+            .order('is_primary', desc=True) \
+            .execute()
+
+        if not rsn_res.data:
             return None, f"Could not find any member with RSN: '{query}' or any metric called '{query}'."
-            
-        member_record = next((r for r in matched_rows if r['is_primary']), matched_rows[0])
+
+        member_record = rsn_res.data[0]
         member_id = member_record['member_id']
         display_rsn = member_record['rsn']
         


### PR DESCRIPTION
member_rsns crossed 1000 rows, so unpaginated selects in resolve_rsn_to_member and other member_rsns lookups were silently truncated, causing newly added members to be unresolvable by RSN (e.g. /memberinfo). Reuse the existing fetch_all_rows pagination helper from clan_sync_logic at all affected call sites.